### PR TITLE
Optionally attach API user permissions to group instead of directly

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -23,7 +23,7 @@ Here's an example snippet for how to use this component.
 ```yaml
 components:
   terraform:
-    aws-saml:
+    saml:
       vars:
         enabled: true
         saml_providers:
@@ -67,6 +67,7 @@ components:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br/>This is for some rare cases where resources want additional configuration of tags<br/>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
+| <a name="input_attach_permissions_to_group"></a> [attach\_permissions\_to\_group](#input\_attach\_permissions\_to\_group) | If true, attach IAM permissions to a group rather than directly to the API user | `bool` | `false` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br/>in the order they appear in the list. New attributes are appended to the<br/>end of the list. The elements of the list are joined by the `delimiter`<br/>and treated as a single ID element. | `list(string)` | `[]` | no |
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br/>See description of individual variables for details.<br/>Leave string and numeric variables as `null` to use default value.<br/>Individual variable settings (non-null) override settings in context object,<br/>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br/>  "additional_tag_map": {},<br/>  "attributes": [],<br/>  "delimiter": null,<br/>  "descriptor_formats": {},<br/>  "enabled": true,<br/>  "environment": null,<br/>  "id_length_limit": null,<br/>  "label_key_case": null,<br/>  "label_order": [],<br/>  "label_value_case": null,<br/>  "labels_as_tags": [<br/>    "unset"<br/>  ],<br/>  "name": null,<br/>  "namespace": null,<br/>  "regex_replace_chars": null,<br/>  "stage": null,<br/>  "tags": {},<br/>  "tenant": null<br/>}</pre> | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br/>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
@@ -103,4 +104,4 @@ components:
 - [cloudposse/terraform-aws-components](https://github.com/cloudposse/terraform-aws-components/tree/main/modules/sso) -
   Cloud Posse's upstream component
 
-[<img src="https://cloudposse.com/logo-300x69.svg" height="32" align="right"/>](https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-saml&utm_content=)
+[<img src="https://cloudposse.com/logo-300x69.svg" height="32" align="right"/>](https://cpco.io/component)

--- a/src/main.tf
+++ b/src/main.tf
@@ -15,6 +15,8 @@ module "okta_api_user" {
 
   attributes = [each.key, "oktaapi"]
 
+  attach_permissions_to_group = var.attach_permissions_to_group
+
   context = module.this.context
 }
 

--- a/src/modules/okta-user/context.tf
+++ b/src/modules/okta-user/context.tf
@@ -264,8 +264,8 @@ variable "descriptor_formats" {
     Describe additional descriptors to be output in the `descriptors` output map.
     Map of maps. Keys are names of descriptors. Values are maps of the form
     `{
-      format = string
-      labels = list(string)
+       format = string
+       labels = list(string)
     }`
     (Type is `any` so the map values can later be enhanced to provide additional options.)
     `format` is a Terraform format string to be passed to the `format()` function.

--- a/src/modules/okta-user/variables.tf
+++ b/src/modules/okta-user/variables.tf
@@ -1,5 +1,13 @@
 # AWS KMS alias used for encryption/decryption
 # default is alias used in SSM
 variable "kms_alias_name" {
-  default = "alias/aws/ssm"
+  type        = string
+  default     = "alias/aws/ssm"
+  description = "The name of the KMS alias used for encryption/decryption of SSM parameters (API key)"
+}
+
+variable "attach_permissions_to_group" {
+  type        = bool
+  default     = false
+  description = "If true, attach IAM permissions to a group rather than directly to the API user"
 }

--- a/src/modules/okta-user/versions.tf
+++ b/src/modules/okta-user/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.9.0"
+    }
+  }
+}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -7,3 +7,10 @@ variable "saml_providers" {
   type        = map(string)
   description = "Map of provider names to XML data filenames"
 }
+
+variable "attach_permissions_to_group" {
+  type        = bool
+  default     = false
+  description = "If true, attach IAM permissions to a group rather than directly to the API user"
+  nullable    = false
+}


### PR DESCRIPTION
## what

- Add `attach_permissions_to_group` input, which, when `true`, causes the component to create an IAM group for the API user and attach the IAM policy to the group instead of directly to the user

## why

- Some automated security enforcement tools dictate that permissions should not be directly attached to a user



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added option to attach IAM permissions to a group instead of directly to the API user.
  - Introduced new configuration parameter `attach_permissions_to_group`.

- **Documentation**
  - Updated README with new usage example and parameter description.
  - Improved variable documentation for `kms_alias_name`.

- **Improvements**
  - Enhanced IAM user and group management capabilities.
  - Simplified component naming in usage examples.
  - Specified required Terraform and AWS provider versions for compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->